### PR TITLE
Transform keys to plural forms based on keywords

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 4068ef9b0818aeddbfec81dfeb590cf57afa1c01b9576788c4d87a0ee56c5040
-updated: 2017-07-27T23:05:56.256041473-07:00
+hash: ea7497b43afee00ed76137fc7bdb9a6e90bab97e1dad925f22dc8d74b225a512
+updated: 2017-09-16T18:36:21.6207022-04:00
 imports:
 - name: github.com/andybalholm/cascadia
   version: 349dd0209470eabd9514242c688c403c0926d266
@@ -9,6 +9,8 @@ imports:
   version: a4d79d4487c2430a17d9dc8a1f74d1a6ed6908ca
 - name: github.com/gorilla/mux
   version: ac112f7d75a0714af1bd86ab17749b31f7809640
+- name: github.com/jinzhu/inflection
+  version: 1c35d901db3da928c72a72d8458480cc9ade058f
 - name: github.com/PuerkitoBio/goquery
   version: 8806ada2a4ab225c06e9106f9631be80932db7ce
 - name: github.com/sirupsen/logrus

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,3 +4,4 @@ import:
 - package: github.com/gorilla/handlers
 - package: github.com/gorilla/mux
 - package: github.com/sirupsen/logrus
+- package: github.com/jinzhu/inflection

--- a/ovrstat/models.go
+++ b/ovrstat/models.go
@@ -17,7 +17,7 @@ type PlayerStats struct {
 
 // statsCollection holds a collection of stats for a particular player
 type statsCollection struct {
-	TopHeros    map[string]*topHeroStats `json:"topHeros"`
+	TopHeroes   map[string]*topHeroStats `json:"topHeroes"`
 	CareerStats map[string]*careerStats  `json:"careerStats"`
 }
 

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -157,7 +157,7 @@ func parseCareerStats(careerStatsSelector *goquery.Selection) map[string]*career
 				statSel.Find("td").Each(func(i4 int, statKV *goquery.Selection) {
 					switch i4 {
 					case 0:
-						statKey = cleanJSONKey(statKV.Text())
+						statKey = transformKey(cleanJSONKey(statKV.Text()))
 					case 1:
 						statVal = strings.Replace(statKV.Text(), ",", "", -1) // Removes commas from 1k+ values
 
@@ -243,9 +243,13 @@ func getPrestigeByIcon(levelIcon string) int {
 	return rankMap[string(iconID[1])]
 }
 
+var (
+	keyReplacer = strings.NewReplacer("-", " ", ".", " ", ":", " ", "'", "", "ú", "u", "ö", "o")
+)
+
 // cleanJSONKey
 func cleanJSONKey(str string) string {
-	str = strings.Replace(str, "-", " ", -1) // Removes all dashes from titles
+	str = keyReplacer.Replace(str) // Removes all dashes, dots, and colons from titles
 	str = strings.ToLower(str)
 	str = strings.Title(str)                // Uppercases lowercase leading characters
 	str = strings.Replace(str, " ", "", -1) // Removes Spaces

--- a/ovrstat/player_stats.go
+++ b/ovrstat/player_stats.go
@@ -84,7 +84,7 @@ func parseGeneralInfo(s *goquery.Selection) PlayerStats {
 // parseDetailedStats populates the passed stats collection with detailed statistics
 func parseDetailedStats(playModeSelector *goquery.Selection) statsCollection {
 	var sc statsCollection
-	sc.TopHeros = parseHeroStats(playModeSelector.Find("section.hero-comparison-section").First())
+	sc.TopHeroes = parseHeroStats(playModeSelector.Find("section.hero-comparison-section").First())
 	sc.CareerStats = parseCareerStats(playModeSelector.Find("section.career-stats-section").First())
 	return sc
 }

--- a/ovrstat/pluralize.go
+++ b/ovrstat/pluralize.go
@@ -1,0 +1,97 @@
+package ovrstat
+
+import (
+	"strings"
+	"unicode"
+	"sort"
+	"github.com/jinzhu/inflection"
+)
+
+var (
+	keywords = []string{
+		"kill",
+		"multikill",
+		"death",
+		"generator",
+		"shield",
+		"enemy",
+		"turret",
+		"hit",
+		"pad",
+		"blow",
+		"assist",
+		"elimination",
+		"card",
+		"dragonblade",
+		"player",
+		"bomb",
+	}
+)
+
+func transformKey(str string) string {
+	split := splitKeywords(str)
+
+	sort.Sort(split)
+
+	var lowerKeyPart string
+
+	for _, keyPart := range split {
+		lowerKeyPart = strings.ToLower(keyPart)
+
+		for _, keyword := range keywords {
+			if keyword == lowerKeyPart {
+				replacement := inflection.Plural(keyword)
+
+				if unicode.IsUpper(rune(keyPart[0])) {
+					replacement = strings.ToUpper(replacement[0:1]) + replacement[1:]
+				}
+
+				str = strings.Replace(str, keyPart, replacement, 1)
+
+				return str
+			}
+		}
+	}
+
+	if str == "allDamageDone" {
+		return "damageDone"
+	}
+
+	return str
+}
+
+type Keywords []string
+
+func (s Keywords) Len() int {
+	return len(s)
+}
+
+func (s Keywords) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Keywords) Less(i, j int) bool {
+	return sliceIndexOf(keywords, s[i]) < sliceIndexOf(keywords, s[j])
+}
+
+func splitKeywords(str string) Keywords {
+	var words Keywords
+	l := 0
+	for s := str; s != ""; s = s[l:] {
+		l = strings.IndexFunc(s[1:], unicode.IsUpper) + 1
+		if l <= 0 {
+			l = len(s)
+		}
+		words = append(words, s[:l])
+	}
+	return words
+}
+
+func sliceIndexOf(s []string, str string) int {
+	for i, val := range s {
+		if strings.ToLower(val) == strings.ToLower(str) {
+			return i
+		}
+	}
+	return len(s)
+}


### PR DESCRIPTION
This ensures the API will always return keys which we expect, instead of sometimes singular and sometimes plural. Blizzard often uses the singular form for values with a single item (kill, elimination, etc), this will hopefully fix all cases of that.

This also fixes the pluralization of Hero, and updates it to "Heroes". This does change the output, as instead of `topHeros` it'll be `topHeroes`.